### PR TITLE
Performance Improvements

### DIFF
--- a/Benchmark/Benchmark.cs
+++ b/Benchmark/Benchmark.cs
@@ -1,0 +1,39 @@
+﻿using Analyzer.BeatmapScanner.Algorithm;
+using beatleader_analyzer;
+using beatleader_parser;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Jobs;
+using Parser.Map;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Benchmark
+{
+    [MemoryDiagnoser]
+    [SimpleJob(RuntimeMoniker.Net481)]
+    [SimpleJob(RuntimeMoniker.Net80)]
+    public class Benchmark
+    {
+        [ParamsAllValues]
+        public bool UseParallelFor { get; set; }
+        BeatmapV3 map;
+        Analyze analyzer;
+
+        [GlobalSetup]
+        public void Globalsetup()
+        {
+            map = new Parse().TryDownloadLink(@"https://r2cdn.beatsaver.com/522d0727d30469e09522d193438ec3698b757693.zip").Last();
+            analyzer = new Analyze();
+        }
+
+        [Benchmark]
+        public void GetRating()
+        {
+            SwingCurve.UseParallel = UseParallelFor;
+            analyzer.GetRating(map);
+        }
+    }
+}

--- a/Benchmark/Benchmark.csproj
+++ b/Benchmark/Benchmark.csproj
@@ -1,0 +1,34 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFrameworks>net481;net8.0</TargetFrameworks>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="BenchmarkDotNet" Version="0.13.10" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="NVorbis" Version="0.10.5" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net481' ">
+    <ProjectReference Include="..\beatleader-analyzer\Analyzer.csproj" >
+      <SetTargetFramework>TargetFramework=netstandard2.0</SetTargetFramework>
+    </ProjectReference>
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net8.0' ">
+    <ProjectReference Include="..\beatleader-analyzer\Analyzer.csproj" >
+      <SetTargetFramework>TargetFramework=net8.0</SetTargetFramework>
+    </ProjectReference>
+  </ItemGroup>
+  
+
+  <ItemGroup>
+    <Reference Include="Parser">
+      <HintPath>..\beatleader-analyzer\dll\Parser.dll</HintPath>
+    </Reference>
+  </ItemGroup>
+
+</Project>

--- a/Benchmark/Program.cs
+++ b/Benchmark/Program.cs
@@ -1,0 +1,21 @@
+﻿using BenchmarkDotNet.Running;
+
+namespace Benchmark
+{
+    internal class Program
+    {
+        static void Main(string[] args)
+        {
+#if DEBUG
+            var bench = new Benchmark();
+            bench.Globalsetup();
+            while (true)
+            {
+                bench.GetRating();
+            }
+#else
+            BenchmarkRunner.Run<Benchmark>();
+#endif
+        }
+    }
+}

--- a/beatleader-analyzer.sln
+++ b/beatleader-analyzer.sln
@@ -3,7 +3,9 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.7.34202.233
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Analyzer", "beatleader-analyzer\Analyzer.csproj", "{6FBDADE4-F052-4F38-A8FD-8908A6CE07A7}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Benchmark", "Benchmark\Benchmark.csproj", "{A29703E3-2E7F-4BDC-8D78-8BC69610F740}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Analyzer", "beatleader-analyzer\Analyzer.csproj", "{239368E3-228D-471B-AD4F-25F3E81FEBD7}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -11,10 +13,14 @@ Global
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{6FBDADE4-F052-4F38-A8FD-8908A6CE07A7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{6FBDADE4-F052-4F38-A8FD-8908A6CE07A7}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{6FBDADE4-F052-4F38-A8FD-8908A6CE07A7}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{6FBDADE4-F052-4F38-A8FD-8908A6CE07A7}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A29703E3-2E7F-4BDC-8D78-8BC69610F740}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A29703E3-2E7F-4BDC-8D78-8BC69610F740}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A29703E3-2E7F-4BDC-8D78-8BC69610F740}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A29703E3-2E7F-4BDC-8D78-8BC69610F740}.Release|Any CPU.Build.0 = Release|Any CPU
+		{239368E3-228D-471B-AD4F-25F3E81FEBD7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{239368E3-228D-471B-AD4F-25F3E81FEBD7}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{239368E3-228D-471B-AD4F-25F3E81FEBD7}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{239368E3-228D-471B-AD4F-25F3E81FEBD7}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/beatleader-analyzer/Analyzer.csproj
+++ b/beatleader-analyzer/Analyzer.csproj
@@ -1,11 +1,21 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
 	  <!--net48-->
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;net8.0</TargetFrameworks>
     <RootNamespace>beatleader_analyzer</RootNamespace>
 	  <LangVersion>preview</LangVersion>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="PolySharp" Version="1.13.2">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="System.Memory" Version="4.5.5" />
+    <PackageReference Include="System.Reflection.Emit" Version="4.7.0" />
+    <PackageReference Include="System.Runtime.InteropServices" Version="4.3.0" />
+  </ItemGroup>
 
   <ItemGroup>
     <Reference Include="Parser">

--- a/beatleader-analyzer/BeatmapScanner/Algorithm/Analyze.cs
+++ b/beatleader-analyzer/BeatmapScanner/Algorithm/Analyze.cs
@@ -90,6 +90,8 @@ namespace Analyzer.BeatmapScanner.Algorithm
 
             if (data.Count > 2)
             {
+                // We can sort the original list here, as only count and average is accessed after this line
+                data.Sort(CompareAngleAndPathStrain);
                 tech = AverageAnglePath(CollectionsMarshal.AsSpan(data)[(int)(data.Count * 0.25)..]);
             }
 
@@ -116,6 +118,8 @@ namespace Analyzer.BeatmapScanner.Algorithm
 
             return value;
         }
+
+        private static readonly Comparer<SwingData> CompareAngleAndPathStrain = Comparer<SwingData>.Create((a, b) => (a.AngleStrain + a.PathStrain).CompareTo(b.AngleStrain + b.PathStrain));
 
         public static double AverageAnglePath(Span<SwingData> list)
         {

--- a/beatleader-analyzer/BeatmapScanner/Algorithm/Analyze.cs
+++ b/beatleader-analyzer/BeatmapScanner/Algorithm/Analyze.cs
@@ -2,6 +2,8 @@
 using System.Collections.Generic;
 using System;
 using System.Linq;
+using System.Runtime.InteropServices;
+using static beatleader_analyzer.BeatmapScanner.Helper.Performance;
 
 namespace Analyzer.BeatmapScanner.Algorithm
 {
@@ -19,7 +21,7 @@ namespace Analyzer.BeatmapScanner.Algorithm
             List<List<SwingData>> bluePatternData = new();
             List<SwingData> data = new();
 
-            if (red.Count() > 2)
+            if (red.Count > 2)
             {
                 FlowDetector.Detect(red, false);
                 redSwingData = SwingProcesser.Process(red);
@@ -42,7 +44,7 @@ namespace Analyzer.BeatmapScanner.Algorithm
                 }
             }
 
-            if (blue.Count() > 2)
+            if (blue.Count > 2)
             {
                 FlowDetector.Detect(blue, true);
                 blueSwingData = SwingProcesser.Process(blue);
@@ -86,26 +88,24 @@ namespace Analyzer.BeatmapScanner.Algorithm
                 rightDiff /= 5;
             }
 
-            if (data.Count() > 2)
+            if (data.Count > 2)
             {
-                var test = data.Select(c => c.AngleStrain + c.PathStrain).ToList();
-                test.Sort();
-                tech = test.Skip((int)(data.Count() * 0.25)).Average();
+                tech = AverageAnglePath(CollectionsMarshal.AsSpan(data)[(int)(data.Count * 0.25)..]);
             }
 
             double balanced_pass = Math.Max(leftDiff, rightDiff) * 0.8 + Math.Min(leftDiff, rightDiff) * 0.2;
 
             value.Add(balanced_pass);
-            double balanced_tech = tech * (-(Math.Pow(Math.Abs(-1.4), -balanced_pass)) + 1);
+            double balanced_tech = tech * (-(Math.Pow(1.4, -balanced_pass)) + 1);
             value.Add(balanced_tech);
-            double low_note_nerf = 1 / (1 + Math.Pow(Math.E, -0.6 * (data.Count() / 100 + 1.5)));
+            double low_note_nerf = 1 / (1 + Math.Pow(Math.E, -0.6 * (data.Count / 100 + 1.5)));
             value.Add(low_note_nerf);
 
-            if(data.Count() > 2)
+            if(data.Count > 2)
             {
-                double linear = data.Where(x => x.Linear == true).Count() / (double)data.Count();
+                double linear = data.Where(x => x.Linear == true).Count() / (double)data.Count;
                 value.Add(linear);
-                double pattern = data.Select(x => x.Pattern).Average();
+                double pattern = AveragePattern(CollectionsMarshal.AsSpan(data));
                 value.Add(pattern);
             }
             else
@@ -115,6 +115,26 @@ namespace Analyzer.BeatmapScanner.Algorithm
             }
 
             return value;
+        }
+
+        public static double AverageAnglePath(Span<SwingData> list)
+        {
+            double sum = 0;
+            foreach(SwingData val in list)
+            {
+                sum += val.AngleStrain + val.PathStrain;
+            }
+            return sum / list.Length;
+        }
+
+        public static double AveragePattern(Span<SwingData> list)
+        {
+            double sum = 0;
+            foreach(SwingData val in list)
+            {
+                sum += val.Pattern;
+            }
+            return sum / list.Length;
         }
     }
 }

--- a/beatleader-analyzer/BeatmapScanner/Algorithm/DiffToPass.cs
+++ b/beatleader-analyzer/BeatmapScanner/Algorithm/DiffToPass.cs
@@ -2,7 +2,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using static Analyzer.BeatmapScanner.Helper.Helper;
+using static beatleader_analyzer.BeatmapScanner.Helper.Performance;
 
 namespace Analyzer.BeatmapScanner.Algorithm
 {
@@ -10,27 +10,27 @@ namespace Analyzer.BeatmapScanner.Algorithm
     {
         public static List<SwingData> CalcSwingDiff(List<SwingData> swingData, double bpm)
         {
-            if (swingData.Count() == 0)
+            if (swingData.Count == 0)
             {
                 return swingData;
             }
             double bps = bpm / 60;
             var data = new List<SData>();
             swingData[0].SwingDiff = 0;
-            for (int i = 1; i < swingData.Count(); i++)
+            for (int i = 1; i < swingData.Count; i++)
             {
                 double distanceDiff = swingData[i].PreviousDistance / (swingData[i].PreviousDistance + 3) + 1;
                 data.Add(new SData(swingData[i].SwingFrequency * distanceDiff * bps));
                 if (swingData[i].Reset)
                 {
-                    data.Last().SwingSpeed *= 2;
+                    data[^1].SwingSpeed *= 2;
                 }
                 double xHitDist = swingData[i].EntryPosition.x - swingData[i].ExitPosition.x;
                 double yHitDist = swingData[i].EntryPosition.y - swingData[i].ExitPosition.y;
-                data.Last().HitDistance = Math.Sqrt(Math.Pow(xHitDist, 2) + Math.Pow(yHitDist, 2));
-                data.Last().HitDiff = data.Last().HitDistance / (data.Last().HitDistance + 2) + 1;
-                data.Last().Stress = (Math.Min(swingData[i].AngleStrain * 0.5, 0.5) + swingData[i].PathStrain) * data.Last().HitDiff;
-                swingData[i].SwingDiff = data.Last().SwingSpeed * (-Math.Pow(1.4, -data.Last().SwingSpeed) + 1) * (data.Last().Stress / (data.Last().Stress + 2) + 1);
+                data[^1].HitDistance = Math.Sqrt(Math.Pow(xHitDist, 2) + Math.Pow(yHitDist, 2));
+                data[^1].HitDiff = data[^1].HitDistance / (data[^1].HitDistance + 2) + 1;
+                data[^1].Stress = (Math.Min(swingData[i].AngleStrain * 0.5, 0.5) + swingData[i].PathStrain) * data[^1].HitDiff;
+                swingData[i].SwingDiff = data[^1].SwingSpeed * (-Math.Pow(1.4, -data[^1].SwingSpeed) + 1) * (data[^1].Stress / (data[^1].Stress + 2) + 1);
             }
 
             return swingData;
@@ -39,27 +39,20 @@ namespace Analyzer.BeatmapScanner.Algorithm
 
         public static double CalcAverage(List<SwingData> swingData, int WINDOW)
         {
-            if (swingData.Count() < 2)
+            if (swingData.Count < 2)
             {
                 return 0;
             }
 
-            var qDiff = new Queue<double>();
+            var qDiff = new CircularBuffer(stackalloc double[WINDOW]);
             var difficultyIndex = new List<double>();
 
-            for (int i = 1; i < swingData.Count(); i++)
+            for (int i = 1; i < swingData.Count; i++)
             {
-                if (i > WINDOW)
-                {
-                    qDiff.Dequeue();
-                }
                 qDiff.Enqueue(swingData[i].SwingDiff);
-                List<double> tempList = qDiff.ToList();
-                tempList.Sort();
-                tempList.Reverse();
                 if (i >= WINDOW)
                 {
-                    var windowDiff = tempList.Average() * 0.8;
+                    var windowDiff = Average(qDiff.Buffer) * 0.8;
                     difficultyIndex.Add(windowDiff);
                 }
             }

--- a/beatleader-analyzer/BeatmapScanner/Algorithm/FlowDetector.cs
+++ b/beatleader-analyzer/BeatmapScanner/Algorithm/FlowDetector.cs
@@ -13,7 +13,7 @@ namespace Analyzer.BeatmapScanner.Algorithm
     {
         public static void Detect(List<Cube> cubes, bool leftOrRight)
         {
-            if (cubes.Count() < 2)
+            if (cubes.Count < 2)
             {
                 return;
             }
@@ -101,7 +101,7 @@ namespace Analyzer.BeatmapScanner.Algorithm
                 }
             }
             // Rest of the notes
-            for (int i = 2; i < cubes.Count() - 1; i++)
+            for (int i = 2; i < cubes.Count - 1; i++)
             {
                 if (cubes[i].CutDirection == 8)
                 { 
@@ -202,7 +202,7 @@ namespace Analyzer.BeatmapScanner.Algorithm
                 }
             }
             // Fix dot flow that only work from one way
-            for (int i = 2; i < cubes.Count() - 2; i++)
+            for (int i = 2; i < cubes.Count - 2; i++)
             {
                 if (cubes[i].CutDirection == 8 && !cubes[i].Pattern)
                 {
@@ -221,39 +221,39 @@ namespace Analyzer.BeatmapScanner.Algorithm
                 }
             }
             // Handle the last notes
-            if (cubes.Last().CutDirection == 8)
+            if (cubes[^1].CutDirection == 8)
             {
-                if ((cubes.Last().Time - cubes[cubes.Count() - 2].Time <= 0.25 && SliderCond(cubes[cubes.Count() - 2], cubes.Last(), lastSimPos))
-                    || cubes.Last().Time - cubes[cubes.Count() - 2].Time <= 0.1429)
+                if ((cubes[^1].Time - cubes[^2].Time <= 0.25 && SliderCond(cubes[^2], cubes[^1], lastSimPos))
+                    || cubes[^1].Time - cubes[^2].Time <= 0.1429)
                 {
-                    (cubes.Last().Direction, lastSimPos) = FindAngleViaPos(cubes, cubes.Count - 1, cubes.Count - 2, cubes[cubes.Count() - 2].Direction, true);
-                    if (cubes[cubes.Count() - 2].CutDirection == 8)
+                    (cubes[^1].Direction, lastSimPos) = FindAngleViaPos(cubes, cubes.Count - 1, cubes.Count - 2, cubes[^2].Direction, true);
+                    if (cubes[^2].CutDirection == 8)
                     {
-                        cubes[cubes.Count() - 2].Direction = cubes.Last().Direction;
+                        cubes[^2].Direction = cubes[^1].Direction;
                     }
-                    cubes.Last().Pattern = true;
-                    if (!cubes[cubes.Count() - 2].Pattern)
+                    cubes[^1].Pattern = true;
+                    if (!cubes[^2].Pattern)
                     {
-                        cubes[cubes.Count() - 2].Pattern = true;
-                        cubes[cubes.Count() - 2].Head = true;
+                        cubes[^2].Pattern = true;
+                        cubes[^2].Head = true;
                     }
                 }
                 else
                 {
-                    (cubes.Last().Direction, lastSimPos) = FindAngleViaPos(cubes, cubes.Count - 1, cubes.Count - 2, cubes[cubes.Count() - 2].Direction, false);
+                    (cubes[^1].Direction, lastSimPos) = FindAngleViaPos(cubes, cubes.Count - 1, cubes.Count - 2, cubes[^2].Direction, false);
                 }
             }
             else
             {
-                cubes.Last().Direction = Mod(DirectionToDegree[cubes.Last().CutDirection] + cubes.Last().AngleOffset, 360);
-                if (((cubes.Last().Time - cubes[cubes.Count() - 2].Time < 0.25 && SliderCond(cubes[cubes.Count() - 2], cubes.Last(), lastSimPos))
-                    || cubes.Last().Time - cubes[cubes.Count() - 2].Time <= 0.1429) && IsSameDir(cubes[cubes.Count() - 2].Direction, cubes.Last().Direction))
+                cubes[^1].Direction = Mod(DirectionToDegree[cubes[^1].CutDirection] + cubes[^1].AngleOffset, 360);
+                if (((cubes[^1].Time - cubes[^2].Time < 0.25 && SliderCond(cubes[^2], cubes[^1], lastSimPos))
+                    || cubes[^1].Time - cubes[^2].Time <= 0.1429) && IsSameDir(cubes[^2].Direction, cubes[^1].Direction))
                 {
-                    cubes.Last().Pattern = true;
-                    if (!cubes[cubes.Count() - 2].Pattern)
+                    cubes[^1].Pattern = true;
+                    if (!cubes[^2].Pattern)
                     {
-                        cubes[cubes.Count() - 2].Pattern = true;
-                        cubes[cubes.Count() - 2].Head = true;
+                        cubes[^2].Pattern = true;
+                        cubes[^2].Head = true;
                     }
                 }
             }

--- a/beatleader-analyzer/BeatmapScanner/Algorithm/Linear.cs
+++ b/beatleader-analyzer/BeatmapScanner/Algorithm/Linear.cs
@@ -22,7 +22,7 @@ namespace Analyzer.BeatmapScanner.Algorithm
             swings[0].Linear = true;
             swings[1].Linear = true;
 
-            for (int i = 2; i < swings.Count(); i++)
+            for (int i = 2; i < swings.Count; i++)
             {
                 if (IsInLinearPath(swings[i - 2], swings[i - 1], swings[i]))
                 {

--- a/beatleader-analyzer/BeatmapScanner/Algorithm/ParityPredictor.cs
+++ b/beatleader-analyzer/BeatmapScanner/Algorithm/ParityPredictor.cs
@@ -10,19 +10,19 @@ namespace Analyzer.BeatmapScanner.Algorithm
     {
         public static List<SwingData> Predict(List<List<SwingData>> patternData, bool leftOrRight)
         {
-            if (patternData.Count() < 1)
+            if (patternData.Count < 1)
             {
                 return null;
             }
 
             var newPatternData = new List<SwingData>();
 
-            for (int p = 0; p < patternData.Count(); p++)
+            for (int p = 0; p < patternData.Count; p++)
             {
                 var testData1 = patternData[p];
                 var testData2 = SwingData.DeepCopy(patternData[p]);
 
-                for (int i = 0; i < testData1.Count(); i++)
+                for (int i = 0; i < testData1.Count; i++)
                 {
                     if (i > 0)
                     {
@@ -43,7 +43,7 @@ namespace Analyzer.BeatmapScanner.Algorithm
                         testData1[0].Forehand = true;
                     }
                 }
-                for (int i = 0; i < testData2.Count(); i++)
+                for (int i = 0; i < testData2.Count; i++)
                 {
                     if (i > 0)
                     {
@@ -76,7 +76,7 @@ namespace Analyzer.BeatmapScanner.Algorithm
                     newPatternData.AddRange(testData2);
                 }
             }
-            for (int i = 0; i < newPatternData.Count(); i++)
+            for (int i = 0; i < newPatternData.Count; i++)
             {
                 newPatternData[i].AngleStrain = SwingAngleStrainCalc(new List<SwingData> { newPatternData[i] }, leftOrRight) * 2;
             }

--- a/beatleader-analyzer/BeatmapScanner/Algorithm/PatternSplitter.cs
+++ b/beatleader-analyzer/BeatmapScanner/Algorithm/PatternSplitter.cs
@@ -8,14 +8,14 @@ namespace Analyzer.BeatmapScanner.Algorithm
     {
         public static List<List<SwingData>> Split(List<SwingData> swingData)
         {
-            if (swingData.Count() < 2)
+            if (swingData.Count < 2)
             {
                 return null;
             }
 
-            for (int i = 0; i < swingData.Count(); i++)
+            for (int i = 0; i < swingData.Count; i++)
             {
-                if (i > 0 && i + 1 < swingData.Count())
+                if (i > 0 && i + 1 < swingData.Count)
                 {
                     swingData[i].SwingFrequency = 2 / (swingData[i + 1].Time - swingData[i - 1].Time);
                 }
@@ -31,7 +31,7 @@ namespace Analyzer.BeatmapScanner.Algorithm
             List<List<SwingData>> patternList = new();
             List<SwingData> tempPList = new();
 
-            for (int i = 0; i < swingData.Count(); i++)
+            for (int i = 0; i < swingData.Count; i++)
             {
                 if (i > 0)
                 {
@@ -40,8 +40,8 @@ namespace Analyzer.BeatmapScanner.Algorithm
                         if (!patternFound)
                         {
                             patternFound = true;
-                            tempPList.Remove(tempPList.Last());
-                            if (tempPList.Count() > 0)
+                            tempPList.Remove(tempPList[^1]);
+                            if (tempPList.Count > 0)
                             {
                                 patternList.Add(tempPList);
                             }
@@ -54,7 +54,7 @@ namespace Analyzer.BeatmapScanner.Algorithm
                     }
                     else
                     {
-                        if (tempPList.Count() > 0 && patternFound)
+                        if (tempPList.Count > 0 && patternFound)
                         {
                             tempPList.Add(swingData[i]);
                             patternList.Add(tempPList);
@@ -73,7 +73,7 @@ namespace Analyzer.BeatmapScanner.Algorithm
                 }
             }
 
-            if (tempPList.Count > 0 && patternList.Count() == 0)
+            if (tempPList.Count > 0 && patternList.Count == 0)
             {
                 patternList.Add(tempPList);
             }

--- a/beatleader-analyzer/BeatmapScanner/Algorithm/SwingCurve.cs
+++ b/beatleader-analyzer/BeatmapScanner/Algorithm/SwingCurve.cs
@@ -45,13 +45,13 @@ namespace Analyzer.BeatmapScanner.Algorithm
                 Point point2 = new(point3.X - 1 * Math.Cos(ConvertDegreesToRadians(swingData[i].Angle)),
                     point3.Y - 1 * Math.Sin(ConvertDegreesToRadians(swingData[i].Angle)));
 
-                List<Point> points = new()
-                {
+                List<Point> points =
+                [
                     point0,
                     point1,
                     point2,
                     point3
-                };
+                ];
 
                 var point = BezierCurve(points);
 
@@ -59,10 +59,10 @@ namespace Analyzer.BeatmapScanner.Algorithm
                 List<double> angleChangeList = new(point.Count);
                 List<double> angleList = new(point.Count);
                 double distance = 0;
-                for (int f = point.Count - 1; f >= 1; f--)
+                for (int f = point.Count - 2; f >= 0; f--)
                 {
-                    angleList.Add(Mod(ConvertRadiansToDegrees(Math.Atan2(point[f].Y - point[f - 1].Y, point[f].X - point[f - 1].X)), 360));
-                    distance += Math.Sqrt(Math.Pow(point[f].Y - point[f - 1].Y, 2) + Math.Pow(point[f].X - point[f - 1].X, 2));
+                    angleList.Add(Mod(ConvertRadiansToDegrees(Math.Atan2(point[f].Y - point[f + 1].Y, point[f].X - point[f + 1].X)), 360));
+                    distance += Math.Sqrt(Math.Pow(point[f].Y - point[f + 1].Y, 2) + Math.Pow(point[f].X - point[f + 1].X, 2));
                     if (f < point.Count - 2)
                     {
                         angleChangeList.Add(180 - Math.Abs(Math.Abs(angleList[^1] - angleList[^2]) - 180));
@@ -138,16 +138,6 @@ namespace Analyzer.BeatmapScanner.Algorithm
                     ForContent(i);
                 }
             }
-        }
-
-        public static double Average(Span<double> list)
-        {
-            double sum = 0;
-            foreach(double val in list)
-            {
-                sum += val;
-            }
-            return sum / list.Length;
         }
     }
 }

--- a/beatleader-analyzer/BeatmapScanner/Algorithm/SwingCurve.cs
+++ b/beatleader-analyzer/BeatmapScanner/Algorithm/SwingCurve.cs
@@ -5,14 +5,19 @@ using Analyzer.BeatmapScanner.Data;
 using System.Collections.Generic;
 using System;
 using System.Linq;
+using System.Runtime.InteropServices;
+using System.Threading.Tasks;
+using System.Runtime.CompilerServices;
+using static beatleader_analyzer.BeatmapScanner.Helper.Performance;
 
 namespace Analyzer.BeatmapScanner.Algorithm
 {
-    internal class SwingCurve
+    public class SwingCurve
     {
+        public static bool UseParallel { get; set; } = true;
         public static void Calc(List<SwingData> swingData, bool leftOrRight)
         {
-            if (swingData.Count() < 2)
+            if (swingData.Count < 2)
             {
                 return;
             }
@@ -30,7 +35,8 @@ namespace Analyzer.BeatmapScanner.Algorithm
             swingData[0].CurveComplexity = 0;
             swingData[0].AnglePathStrain = 0;
 
-            for (int i = 1; i < swingData.Count(); i++)
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            void ForContent(int i)
             {
                 Point point0 = new(swingData[i - 1].ExitPosition.x, swingData[i - 1].ExitPosition.y);
                 Point point1 = new(point0.X + 1 * Math.Cos(ConvertDegreesToRadians(swingData[i - 1].Angle)),
@@ -47,21 +53,19 @@ namespace Analyzer.BeatmapScanner.Algorithm
                     point3
                 };
 
-                var point = BezierCurve(points, 25);
-
-                point.Reverse();
+                var point = BezierCurve(points);
 
                 positionComplexity = 0;
-                List<double> angleChangeList = new();
-                List<double> angleList = new();
+                List<double> angleChangeList = new(point.Count);
+                List<double> angleList = new(point.Count);
                 double distance = 0;
-                for (int f = 1; f < point.Count(); f++)
+                for (int f = point.Count - 1; f >= 1; f--)
                 {
                     angleList.Add(Mod(ConvertRadiansToDegrees(Math.Atan2(point[f].Y - point[f - 1].Y, point[f].X - point[f - 1].X)), 360));
                     distance += Math.Sqrt(Math.Pow(point[f].Y - point[f - 1].Y, 2) + Math.Pow(point[f].X - point[f - 1].X, 2));
-                    if (f > 1)
+                    if (f < point.Count - 2)
                     {
-                        angleChangeList.Add(180 - Math.Abs(Math.Abs(angleList.Last() - angleList[angleList.Count() - 2]) - 180));
+                        angleChangeList.Add(180 - Math.Abs(Math.Abs(angleList[^1] - angleList[^2]) - 180));
                     }
                 }
                 distance -= 0.75;
@@ -92,7 +96,7 @@ namespace Analyzer.BeatmapScanner.Algorithm
                     }
                 }
 
-                double lengthOfList = angleChangeList.Count() * 0.6;
+                double lengthOfList = angleChangeList.Count * 0.6;
                 double first;
                 double last;
 
@@ -108,13 +112,13 @@ namespace Analyzer.BeatmapScanner.Algorithm
                     first = 0.2;
                     last = 0.8;
                 }
-                int pathLookbackIndex = (int)(angleList.Count() * pathLookback);
-                int firstIndex = (int)(angleChangeList.Count() * first) - 1;
-                int lastIndex = (int)(angleChangeList.Count() * last) - 1;
+                int pathLookbackIndex = (int)(angleList.Count * pathLookback);
+                int firstIndex = (int)(angleChangeList.Count * first) - 1;
+                int lastIndex = (int)(angleChangeList.Count * last) - 1;
 
                 // Not sure if the +1 is necessary
-                curveComplexity = Math.Abs((lengthOfList * angleChangeList.GetRange(firstIndex, lastIndex - firstIndex + 1).Average() - 180) / 180);
-                pathAngleStrain = BezierAngleStrainCalc(angleList.GetRange(pathLookbackIndex, angleList.Count - pathLookbackIndex), swingData[i].Forehand, leftOrRight) / angleList.Count * 2;
+                curveComplexity = Math.Abs((lengthOfList * Average(CollectionsMarshal.AsSpan(angleChangeList).Slice(firstIndex, lastIndex - firstIndex + 1)) - 180) / 180);
+                pathAngleStrain = BezierAngleStrainCalc(CollectionsMarshal.AsSpan(angleList)[pathLookbackIndex..angleList.Count], swingData[i].Forehand, leftOrRight) / angleList.Count * 2;
 
                 swingData[i].PositionComplexity = positionComplexity;
                 swingData[i].PreviousDistance = distance;
@@ -122,6 +126,28 @@ namespace Analyzer.BeatmapScanner.Algorithm
                 swingData[i].AnglePathStrain = pathAngleStrain;
                 swingData[i].PathStrain = curveComplexity + pathAngleStrain + positionComplexity;
             }
+
+            if (UseParallel)
+            {
+                Parallel.For(1, swingData.Count, ForContent);
+            }
+            else
+            {
+                for (int i = 1; i < swingData.Count; i++)
+                {
+                    ForContent(i);
+                }
+            }
+        }
+
+        public static double Average(Span<double> list)
+        {
+            double sum = 0;
+            foreach(double val in list)
+            {
+                sum += val;
+            }
+            return sum / list.Length;
         }
     }
 }

--- a/beatleader-analyzer/BeatmapScanner/Algorithm/SwingProcesser.cs
+++ b/beatleader-analyzer/BeatmapScanner/Algorithm/SwingProcesser.cs
@@ -15,18 +15,18 @@ namespace Analyzer.BeatmapScanner.Algorithm
         {
             var swingData = new List<SwingData>();
             (double x, double y) lastSimPos = (0, 0);
-            if (cubes.Count() == 0)
+            if (cubes.Count == 0)
             {
                 return swingData;
             }
 
             swingData.Add(new SwingData(cubes[0].Time, cubes[0].Direction, cubes[0]));
-            (swingData.Last().EntryPosition, swingData.Last().ExitPosition) = CalcBaseEntryExit((cubes[0].Line, cubes[0].Layer), cubes[0].Direction);
-            swingData.Last().Pattern = 0;
+            (swingData[^1].EntryPosition, swingData[^1].ExitPosition) = CalcBaseEntryExit((cubes[0].Line, cubes[0].Layer), cubes[0].Direction);
+            swingData[^1].Pattern = 0;
 
             for (int i = 1; i < cubes.Count - 1; i++)
             {
-                var previousAngle = swingData.Last().Angle;
+                var previousAngle = swingData[^1].Angle;
                 (double x, double y) previousPosition = (cubes[i - 1].Line, cubes[i - 1].Layer);
                 var currentBeat = cubes[i].Time;
                 var currentAngle = cubes[i].Direction;
@@ -36,13 +36,13 @@ namespace Analyzer.BeatmapScanner.Algorithm
                 {
                     // New swing
                     swingData.Add(new SwingData(currentBeat, currentAngle, cubes[i]));
-                    (swingData.Last().EntryPosition, swingData.Last().ExitPosition) = CalcBaseEntryExit(currentPosition, currentAngle);
-                    swingData.Last().Pattern = 0;
+                    (swingData[^1].EntryPosition, swingData[^1].ExitPosition) = CalcBaseEntryExit(currentPosition, currentAngle);
+                    swingData[^1].Pattern = 0;
                     if (cubes[i].Chain)
                     {
-                        swingData.Last().Pattern += 0.1;
+                        swingData[^1].Pattern += 0.1;
                         var angleInRadians = ConvertDegreesToRadians(currentAngle);
-                        swingData.Last().ExitPosition = ((cubes[i].TailLine * 0.333333 + Math.Cos(angleInRadians) * 0.166667 + 0.166667) * cubes[i].Squish, (cubes[i].TailLayer * 0.333333 + Math.Sin(angleInRadians) * 0.166667 + 0.166667) * cubes[i].Squish);
+                        swingData[^1].ExitPosition = ((cubes[i].TailLine * 0.333333 + Math.Cos(angleInRadians) * 0.166667 + 0.166667) * cubes[i].Squish, (cubes[i].TailLayer * 0.333333 + Math.Sin(angleInRadians) * 0.166667 + 0.166667) * cubes[i].Squish);
                     }
                 }
                 else // Pattern
@@ -59,25 +59,25 @@ namespace Analyzer.BeatmapScanner.Algorithm
                     {
                         currentAngle = ReverseCutDirection(currentAngle);
                     }
-                    swingData.Last().Angle = currentAngle;
-                    var xtest = (swingData.Last().EntryPosition.x - (currentPosition.x * 0.333333 - Math.Cos(ConvertDegreesToRadians(currentAngle)) * 0.166667 + 0.166667)) * Math.Cos(ConvertDegreesToRadians(currentAngle));
-                    var ytest = (swingData.Last().EntryPosition.y - (currentPosition.y * 0.333333 - Math.Sin(ConvertDegreesToRadians(currentAngle)) * 0.166667 + 0.166667)) * Math.Sin(ConvertDegreesToRadians(currentAngle));
+                    swingData[^1].Angle = currentAngle;
+                    var xtest = (swingData[^1].EntryPosition.x - (currentPosition.x * 0.333333 - Math.Cos(ConvertDegreesToRadians(currentAngle)) * 0.166667 + 0.166667)) * Math.Cos(ConvertDegreesToRadians(currentAngle));
+                    var ytest = (swingData[^1].EntryPosition.y - (currentPosition.y * 0.333333 - Math.Sin(ConvertDegreesToRadians(currentAngle)) * 0.166667 + 0.166667)) * Math.Sin(ConvertDegreesToRadians(currentAngle));
                     if (xtest <= 0.001 && ytest >= 0.001)
                     {
-                        swingData.Last().EntryPosition = (currentPosition.x * 0.333333 - Math.Cos(ConvertDegreesToRadians(currentAngle)) * 0.166667 + 0.166667, currentPosition.y * 0.333333 - Math.Sin(ConvertDegreesToRadians(currentAngle)) * 0.166667 + 0.166667);
+                        swingData[^1].EntryPosition = (currentPosition.x * 0.333333 - Math.Cos(ConvertDegreesToRadians(currentAngle)) * 0.166667 + 0.166667, currentPosition.y * 0.333333 - Math.Sin(ConvertDegreesToRadians(currentAngle)) * 0.166667 + 0.166667);
                     }
                     else
                     {
-                        swingData.Last().ExitPosition = (currentPosition.x * 0.333333 + Math.Cos(ConvertDegreesToRadians(currentAngle)) * 0.166667 + 0.166667, currentPosition.y * 0.333333 + Math.Sin(ConvertDegreesToRadians(currentAngle)) * 0.166667 + 0.166667);
+                        swingData[^1].ExitPosition = (currentPosition.x * 0.333333 + Math.Cos(ConvertDegreesToRadians(currentAngle)) * 0.166667 + 0.166667, currentPosition.y * 0.333333 + Math.Sin(ConvertDegreesToRadians(currentAngle)) * 0.166667 + 0.166667);
                     }
                     var directionAngle = ReverseCutDirection(Mod(ConvertRadiansToDegrees(Math.Atan2(previousPosition.y - currentPosition.y, previousPosition.x - currentPosition.x)), 360));
                     if (Math.Abs(directionAngle - currentAngle) <= 15)
                     {
-                        swingData.Last().Pattern += 3;
+                        swingData[^1].Pattern += 3;
                     }
                     else
                     {
-                        swingData.Last().Pattern += 1;
+                        swingData[^1].Pattern += 1;
                     }
                 }
             }

--- a/beatleader-analyzer/BeatmapScanner/Data/Cube.cs
+++ b/beatleader-analyzer/BeatmapScanner/Data/Cube.cs
@@ -3,7 +3,7 @@ using Parser.Map.Difficulty.V3.Grid;
 
 namespace Analyzer.BeatmapScanner.Data
 {
-    internal class Cube
+    public class Cube
     {
         public float Time { get; set; } = 0;
         public int Line { get; set; } = 0;

--- a/beatleader-analyzer/BeatmapScanner/Data/SwingData.cs
+++ b/beatleader-analyzer/BeatmapScanner/Data/SwingData.cs
@@ -2,7 +2,7 @@
 
 namespace Analyzer.BeatmapScanner.Data
 {
-    internal class SwingData
+    public class SwingData
     {
         public Cube Start { get; set; } = null;
         public double Time { get; set; } = 0;
@@ -77,15 +77,5 @@ namespace Analyzer.BeatmapScanner.Data
         }
     }
 
-    internal class Point
-    {
-        public double X { get; set; }
-        public double Y { get; set; }
-
-        public Point(double x, double y)
-        {
-            X = x;
-            Y = y;
-        }
-    }
+    internal readonly record struct Point(double X, double Y);
 }

--- a/beatleader-analyzer/BeatmapScanner/Helper/Curve.cs
+++ b/beatleader-analyzer/BeatmapScanner/Helper/Curve.cs
@@ -11,33 +11,29 @@ namespace Analyzer.BeatmapScanner.Helper
         {
             return BinomialCoefficient(n, i) * Math.Pow(t, n - i) * Math.Pow(1 - t, i);
         }
-
-        public static List<Point> BezierCurve(List<Point> points, int nTimes = 1000)
+        const int nTimes = 25;
+        private static readonly double[] tCached = Enumerable.Range(0, nTimes).Select(i => i / (double)(nTimes - 1)).ToArray();
+        public static List<Point> BezierCurve(List<Point> points)
         {
             int nPoints = points.Count;
-            List<double> xPoints = points.Select(p => p.X).ToList();
-            List<double> yPoints = points.Select(p => p.Y).ToList();
-            double[] t = Enumerable.Range(0, nTimes).Select(i => i / (double)(nTimes - 1)).ToArray();
 
-            List<double> resultX = new();
-            List<double> resultY = new();
+            List<Point> result = new(points.Count);
 
             for (int i = 0; i < nTimes; i++)
             {
-                double currentT = t[i];
+                double currentT = tCached[i];
                 double x = 0;
                 double y = 0;
                 for (int j = 0; j < nPoints; j++)
                 {
                     double poly = BernsteinPoly(j, nPoints - 1, currentT);
-                    x += xPoints[j] * poly;
-                    y += yPoints[j] * poly;
+                    x += points[j].X * poly;
+                    y += points[j].Y * poly;
                 }
-                resultX.Add(x);
-                resultY.Add(y);
+                result.Add(new(x, y));
             }
 
-            return resultX.Zip(resultY, (x, y) => new Point(x, y)).ToList();
+            return result;
         }
 
         private static long BinomialCoefficient(int n, int k)

--- a/beatleader-analyzer/BeatmapScanner/Helper/HandlePatternOrdering.cs
+++ b/beatleader-analyzer/BeatmapScanner/Helper/HandlePatternOrdering.cs
@@ -23,13 +23,13 @@ namespace Analyzer.BeatmapScanner.Helper
                 {
                     // Pattern found
                     length = cubes.Where(c => c.Time == cubes[n].Time).Count() - 1;
-                    var arrow = cubes.Where(c => c.CutDirection != 8 && c.Time == cubes[n].Time);
+                    Cube[] arrow = cubes.Where(c => c.CutDirection != 8 && c.Time == cubes[n].Time).ToArray();
                     double direction = 0;
-                    if (arrow.Count() == 0)
+                    if (arrow.Length == 0)
                     {
                         // Pattern got no arrow
                         var foundArrow = cubes.Where(c => c.CutDirection != 8 && c.Time > cubes[n].Time).ToList();
-                        if (foundArrow.Count() > 0)
+                        if (foundArrow.Count > 0)
                         {
                             // An arrow note is found after the note
                             direction = ReverseCutDirection(Mod(DirectionToDegree[foundArrow[0].CutDirection] + foundArrow[0].AngleOffset, 360));
@@ -50,7 +50,7 @@ namespace Analyzer.BeatmapScanner.Helper
                     else
                     {
                         // Use the arrow to determine the direction
-                        direction = ReverseCutDirection(Mod(DirectionToDegree[arrow.Last().CutDirection] + arrow.Last().AngleOffset, 360));
+                        direction = ReverseCutDirection(Mod(DirectionToDegree[arrow[^1].CutDirection] + arrow[^1].AngleOffset, 360));
                     }
                     // Simulate a swing to determine the entry point of the pattern
                     (double x, double y) pos;

--- a/beatleader-analyzer/BeatmapScanner/Helper/Performance.cs
+++ b/beatleader-analyzer/BeatmapScanner/Helper/Performance.cs
@@ -1,0 +1,97 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Numerics;
+using System.Reflection.Emit;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+namespace beatleader_analyzer.BeatmapScanner.Helper
+{
+    internal static class Performance
+    {
+        public static double Average(Span<double> list)
+        {
+            int offset = 0;
+            double sum = 0;
+            // First Sum via SIMD Vector Instructions
+            while(list.Length - offset >= Vector<double>.Count)
+            {
+#if NETSTANDARD2_0_OR_GREATER
+                sum += Vector.Dot(VectorExtensions.Create<double>(list.Slice(offset, Vector<double>.Count)), Vector<double>.One);
+#else
+                sum += Vector.Sum(new Vector<double>(list.Slice(offset, Vector<double>.Count)));
+#endif
+                offset += Vector<double>.Count;
+            }
+            // If we cant fill another Vector but still have data left, we need to sum it by hand
+            if(offset < list.Length)
+            {
+                foreach (double val in list[offset..])
+                {
+                    sum += val;
+                }
+            }
+            return sum / list.Length;
+        }
+
+        /// <summary>
+        /// This type has an internal span, that it fills (and overrides in a circular manner). More info: https://en.wikipedia.org/wiki/Circular_buffer
+        /// Also known as ring buffer
+        /// </summary>
+        /// <param name="buffer"></param>
+        public ref struct CircularBuffer(Span<double> buffer)
+        {
+            public Span<double> Buffer = buffer;
+            int nHead = 0;
+
+            public void Enqueue(double val)
+            {
+                Buffer[nHead++] = val;
+                if(nHead == Buffer.Length)
+                {
+                    nHead = 0;
+                }
+            }
+        }
+
+        #if NETSTANDARD2_0_OR_GREATER
+        public static class CollectionsMarshal
+        {
+            static class ArrayAccessor<T>
+            {
+                private static readonly FieldInfo fInfo = typeof(List<T>).GetField("_items", BindingFlags.Instance | BindingFlags.NonPublic);
+                public static T[] GetItems(List<T> list) => (T[])fInfo.GetValue(list);
+            }
+            public static Span<T> AsSpan<T>(List<T> list) => list is null ? default : new Span<T>(ArrayAccessor<T>.GetItems(list), 0, list.Count);
+        }
+        #endif
+        
+
+        private static class VectorExtensions
+        {
+#if NETSTANDARD2_0_OR_GREATER
+            // Adapted from: source.dot.net/#System.Private.CoreLib/src/libraries/System.Private.CoreLib/src/System/Numerics/Vector_1.cs
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public static Vector<T> Create<T>(ReadOnlySpan<T> values) where T : struct
+            {
+                if(values.Length < Vector<T>.Count)
+                {
+                    ThrowHelper.ThrowArgumentOutOfRangeException(nameof(values));
+                }
+
+                return Unsafe.ReadUnaligned<Vector<T>>(ref Unsafe.As<T, byte>(ref MemoryMarshal.GetReference(values)));
+            }
+
+            private static class ThrowHelper
+            {
+                [MethodImpl(MethodImplOptions.NoInlining)]
+                public static void ThrowArgumentOutOfRangeException(string cMessage) => throw new ArgumentOutOfRangeException(cMessage);
+            }
+#endif
+        }
+    }
+}

--- a/beatleader-analyzer/BeatmapScanner/Helper/Performance.cs
+++ b/beatleader-analyzer/BeatmapScanner/Helper/Performance.cs
@@ -93,5 +93,18 @@ namespace beatleader_analyzer.BeatmapScanner.Helper
             }
 #endif
         }
+
+#if NETSTANDARD2_0_OR_GREATER
+        public static void Sort<T, TComparer>(this ref Span<T> span, TComparer comparer) where TComparer : IComparer<T>
+        {
+            if (span.Length > 1)
+            {
+                // SLOW
+                T[] array = span.ToArray();
+                Array.Sort(array, comparer);
+                span = array.AsSpan();
+            }
+        }
+#endif
     }
 }

--- a/beatleader-analyzer/BeatmapScanner/Helper/SwingAngleStrain.cs
+++ b/beatleader-analyzer/BeatmapScanner/Helper/SwingAngleStrain.cs
@@ -11,7 +11,7 @@ namespace Analyzer.BeatmapScanner.Helper
         {
             double strainAmount = 0;
 
-            for (int i = 0; i < swingData.Count(); i++)
+            for (int i = 0; i < swingData.Count; i++)
             {
                 if (swingData[i].Forehand)
                 {
@@ -40,11 +40,11 @@ namespace Analyzer.BeatmapScanner.Helper
             return strainAmount;
         }
 
-        public static double BezierAngleStrainCalc(List<double> angleData, bool forehand, bool leftOrRight)
+        public static double BezierAngleStrainCalc(Span<double> angleData, bool forehand, bool leftOrRight)
         {
             var strainAmount = 0d;
 
-            for (int i = 0; i < angleData.Count(); i++)
+            for (int i = 0; i < angleData.Length; i++)
             {
                 if (forehand)
                 {


### PR DESCRIPTION
Mostly: Avoid LINQ when possible and use Span where possible
Also added Benchmark and .NET 8 target

I left both options with parallel for and without in there changable via SwingCurve.UseParallel, so the consuming end can decide, which would be more efficient. Default is true.

I tried not to change anything functionally in the rating algorithm. The output of each function should be the same. So please also review, that i didnt break anything 🙏 

Result for Both .NET 8 and NET Framework 4.8.1:
![grafik](https://github.com/BeatLeader/beatleader-analyzer/assets/55283269/b54a2d27-6566-45be-9fa5-3de945f516f7)
In comparison to before:
![grafik](https://github.com/BeatLeader/beatleader-analyzer/assets/55283269/26da66ef-9cc9-45bd-8054-903ea94c0126)
